### PR TITLE
fix: mii interval length counting

### DIFF
--- a/src/mii.rs
+++ b/src/mii.rs
@@ -38,7 +38,7 @@ struct MIIChunkerState {
 
 impl MIIChunkerState {
     fn reset(&mut self) {
-        self.increment_run_length = 0;
+        self.increment_run_length = 1;
         self.previous_value = None;
     }
 }
@@ -56,7 +56,7 @@ impl ChunkerImpl for MIIChunker {
                     }
                 } else {
                     // We don't have an incremental interval anymore.
-                    self.state.increment_run_length = 0;
+                    self.state.increment_run_length = 1;
                 }
             }
 


### PR DESCRIPTION
E.g., the first time that b > previous_value should always evaluate to 2 (not 1) ascending bytes.