### PR TITLE
feat: make running-popcount the default and only option for pci

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -128,7 +128,7 @@ pub use ae::AEChunker;
 pub use bfbc::BFBCChunker;
 pub use gear::{GearChunker, NormalizedChunkingGearChunker};
 pub use mii::MIIChunker;
-pub use pci::{PCIChunker, PCIChunkerNonConst, PCIChunkerRunningPopcount};
+pub use pci::{PCIChunker, PCIChunkerNonConst};
 pub use ram::{MaybeOptimizedRAMChunker, RAMChunker};
 
 #[cfg(test)]


### PR DESCRIPTION
Do we agree to remove the running-popcount option/ make it default?